### PR TITLE
Расширение конфигураций для разработки

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,13 +7,6 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
-translate_tabs_to_spaces = true
 
 [{package.json,.travis.yml,.stylelintrc}]
 indent_size = 2
-
-[*.md]
-indent_size = 2
-quote_type = auto
-max_line_length = off
-trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,13 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
+translate_tabs_to_spaces = true
 
-[{package.json,.travis.yml,.stylelintrc}]]
+[{package.json,.travis.yml,.stylelintrc}]
 indent_size = 2
+
+[*.md]
+indent_size = 2
+quote_type = auto
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,6 @@ node_modules
 # Build directory
 /public
 
-# Files by IDE
-.idea
-.vscode
-*.sublime-project
-*.sublime-workspace
-.brackets.json
-
-# Logs
-npm-debug.log*
-
-# Files of system
-.DS_Store
-._*
-Thumbs.db
+# NOTE: If you need ignore your specific system or IDE setting files,
+# please add them in your global git ignore file.
+# Here "How To" instruction: https://help.github.com/articles/ignoring-files/#create-a-global-gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,18 @@ node_modules
 
 # Build directory
 /public
+
+# Files by IDE
+.idea
+.vscode
+*.sublime-project
+*.sublime-workspace
+.brackets.json
+
+# Logs
+npm-debug.log*
+
+# Files of system
+.DS_Store
+._*
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,3 @@ node_modules
 
 # Build directory
 /public
-
-# NOTE: If you need ignore your specific system or IDE setting files,
-# please add them in your global git ignore file.
-# Here "How To" instruction: https://help.github.com/articles/ignoring-files/#create-a-global-gitignore

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,5 @@
 module.exports = {
     trailingComma: 'es5',
-    tabWidth: 4,
     semi: true,
     singleQuote: true,
 };


### PR DESCRIPTION
## Что изменил

1. Добавил в `.gitignore` системные файлы и файлы IDE
2. Prettier умеет расширяться через настройки EditorConfig, поэтому убрал дублирование tabWidth (это отдельный вопрос, см. ниже)
3. Добавил в `.editorconfig` специфичные настройки для `*.md` файлов

## Вопрос

Почему решили использовать 4 пробела? 😱

По субъективному опыту могу сказать, что если проект пишется на React и разработчик работает большую часть времени на MacOS 13", то это может создать неудобство при чтения кода.