### PR TITLE
Перевел все даты статей в новый формат

### DIFF
--- a/src/templates/article.jsx
+++ b/src/templates/article.jsx
@@ -13,35 +13,20 @@ const Article = props => {
 
     const github = `https://github.com/web-standards-ru/new/blob/master`;
 
-    /**
-     *
-     * @param {string} stringDate, example = '3000.01.01'
-     * @returns {string} beautyDate
-     * or
-     * @returns {string} stringDate if date isn't in format YYYY.MM.DD
-     */
-    const beautyDate = function(stringDate) {
-        const isValidDateReg = /[\d]{4}.[10]{1}[\d]{1}.[0-3]{1}[\d]{1}/;
-        if (
-            stringDate.search(isValidDateReg) !== -1 &&
-            stringDate.length === 10 // 10 is valid length of format 3000.01.01
-        ) {
-            const dateArray = stringDate.split('.');
-            const d = new Date(dateArray[0], dateArray[1], dateArray[2]);
-            return d.toLocaleDateString('ru-RU', {
-                day: 'numeric',
-                month: 'long',
-                year: 'numeric',
-            });
-        } else {
-            return stringDate;
-        }
-    };
+    function toIOS8601(strDate) {
+        return new Date(strDate.replace(/\./g, '-'));
+    }
 
     return (
         <Layout>
             <h1>{frontmatter.title}</h1>
-            <time>{beautyDate(frontmatter.date)}</time>
+            <time>
+                {toIOS8601(frontmatter.date).toLocaleDateString('ru-RU', {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                })}
+            </time>
             <div dangerouslySetInnerHTML={{ __html: html }} />
             <a href={`${github}/content/${path}/index.md`}>
                 Отредактировать на Гитхабе


### PR DESCRIPTION
В реализации добавил функцию toIOS8601 для того чтобы (если/когда) перепишут даты приходящие с бэка было понятно что надо убрать https://github.com/web-standards-ru/new/issues/75